### PR TITLE
Replace OO-interface of Mojo::JSON with functional interface

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,7 @@ WriteMakefile(
     NAME => 'Test::Mojo::Session',
     VERSION_FROM => 'lib/Test/Mojo/Session.pm',
     PREREQ_PM => {
-        Mojolicious => "4.63"
+        Mojolicious => "4.82"
     },
     ABSTRACT_FROM => 'lib/Test/Mojo/Session.pm',
     AUTHOR => 'Andrey Khozov <avkhozov@googlemail.com>',

--- a/lib/Test/Mojo/Session.pm
+++ b/lib/Test/Mojo/Session.pm
@@ -2,6 +2,7 @@ package Test::Mojo::Session;
 
 use Mojo::Base 'Test::Mojo';
 use Mojo::Util qw(b64_decode hmac_sha1_sum);
+use Mojo::JSON qw(decode_json);
 
 our $VERSION = '1.01';
 
@@ -54,7 +55,7 @@ sub _extract_session {
     $sign eq hmac_sha1_sum($value, $_) and $ok = 1 for @{$app->secrets};
     return unless $ok;
 
-    my $session = Mojo::JSON->new->decode(b64_decode $value);
+    my $session = decode_json(b64_decode $value);
     return $session;
 }
 


### PR DESCRIPTION
As of Mojolicious 5.73 the OO-interface of Mojo::JSON is removed.
