### PR TITLE
Add like & unlike methods

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Test::Mojo::Session.
 
 {{$NEXT}}
+    - Added session_like and session_unlike methods.
 
 1.06 2020-05-17T14:35:18Z
     - Added compatibility with Mojo >= 8.36.

--- a/lib/Test/Mojo/Role/Session.pm
+++ b/lib/Test/Mojo/Role/Session.pm
@@ -38,7 +38,9 @@ Test::Mojo::Role::Session - Testing session in Mojolicious applications
     ->session_has('/s1')
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
-    ->session_is('/s3' => [1, 3]);
+    ->session_is('/s3' => [1, 3])
+    ->session_like('/s1' => qr/data/, 's3 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
 
   done_testing();
 

--- a/lib/Test/Mojo/Role/Session.pm
+++ b/lib/Test/Mojo/Role/Session.pm
@@ -39,8 +39,8 @@ Test::Mojo::Role::Session - Testing session in Mojolicious applications
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
     ->session_is('/s3' => [1, 3])
-    ->session_like('/s1' => qr/data/, 's3 contains "data"')
-    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
+    ->session_like('/s1' => qr/data/, 's1 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's1 does not contain "foo"');
 
   done_testing();
 

--- a/lib/Test/Mojo/Session.pm
+++ b/lib/Test/Mojo/Session.pm
@@ -200,9 +200,11 @@ Andrey Khozov, C<avkhozov@googlemail.com>.
 
 Renee, C<reb@perl-services.de>.
 
+Gene Boggs, C<gene.boggs@gmail.com>.
+
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2013-2015, Andrey Khozov.
+Copyright (C) 2013-2022, Andrey Khozov.
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/lib/Test/Mojo/Session.pm
+++ b/lib/Test/Mojo/Session.pm
@@ -198,9 +198,9 @@ Andrey Khozov, C<avkhozov@googlemail.com>.
 
 =head1 CREDITS
 
-Renee, C<reb@perl-services.de>.
+Renee, C<reb@perl-services.de>
 
-Gene Boggs, C<gene.boggs@gmail.com>.
+Gene Boggs, C<gene.boggs@gmail.com>
 
 =head1 COPYRIGHT AND LICENSE
 

--- a/lib/Test/Mojo/Session.pm
+++ b/lib/Test/Mojo/Session.pm
@@ -40,6 +40,20 @@ sub session_is {
   return $self->test('is_deeply', Mojo::JSON::Pointer->new($session)->get($p), $data, $desc);
 }
 
+sub session_like {
+  my ($self, $p, $regex, $desc) = @_;
+  $desc //= qq{session regular expression match for JSON Pointer "$p"};
+  my $session = $self->_extract_session;
+  return $self->test('like', Mojo::JSON::Pointer->new($session)->get($p), qr/$regex/, $desc);
+}
+
+sub session_unlike {
+  my ($self, $p, $regex, $desc) = @_;
+  $desc //= qq{session negated regular expression match for JSON Pointer "$p"};
+  my $session = $self->_extract_session;
+  return $self->test('unlike', Mojo::JSON::Pointer->new($session)->get($p), qr/$regex/, $desc);
+}
+
 sub session_ok {
   my $self    = shift;
   my $session = $self->_extract_session;
@@ -88,7 +102,9 @@ Test::Mojo::Session - Testing session in Mojolicious applications
     ->session_has('/s1')
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
-    ->session_is('/s3' => [1, 3]);
+    ->session_is('/s3' => [1, 3])
+    ->session_like('/s1' => qr/data/, 's3 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
 
   done_testing();
 
@@ -112,7 +128,9 @@ Use L<Test::Mojo::Sesssion> via L<Test::Mojo::WithRoles>.
     ->session_has('/s1')
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
-    ->session_is('/s3' => [1, 3]);
+    ->session_is('/s3' => [1, 3])
+    ->session_like('/s1' => qr/data/, 's3 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
 
   done_testing();
 
@@ -137,17 +155,32 @@ JSON Pointer with L<Mojo::JSON::Pointer>.
 =head2 session_hasnt
 
   $t = $t->session_hasnt('/bar');
-  $t = $t->session_hasnt('/bar', 'session does not has "bar"');
+  $t = $t->session_hasnt('/bar', 'session does not have "bar"');
 
-Check if current session no contains a value that can be identified using the given
+Check if current session does not contain a value that can be identified using the given
 JSON Pointer with L<Mojo::JSON::Pointer>.
 
 =head2 session_is
 
   $t = $t->session_is('/pointer', 'value');
-  $t = $t->session_is('/pointer', 'value', 'right halue');
+  $t = $t->session_is('/pointer', 'value', 'right value');
 
 Check the session using the given JSON Pointer with L<Mojo::JSON::Pointer>.
+
+=head2 session_like
+
+  $t = $t->session_like('/pointer', qr/value/);
+  $t = $t->session_like('/pointer', qr/value/, 'matched value');
+
+Check if current session matches a regular expression.
+
+
+=head2 session_unlike
+
+  $t = $t->session_unlike('/pointer', qr/value/);
+  $t = $t->session_unlike('/pointer', qr/value/, 'did not match value');
+
+Check if current session does not match a regular expression.
 
 =head2 session_ok
 

--- a/lib/Test/Mojo/Session.pm
+++ b/lib/Test/Mojo/Session.pm
@@ -103,8 +103,8 @@ Test::Mojo::Session - Testing session in Mojolicious applications
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
     ->session_is('/s3' => [1, 3])
-    ->session_like('/s1' => qr/data/, 's3 contains "data"')
-    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
+    ->session_like('/s1' => qr/data/, 's1 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's1 does not contain "foo"');
 
   done_testing();
 
@@ -129,8 +129,8 @@ Use L<Test::Mojo::Sesssion> via L<Test::Mojo::WithRoles>.
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
     ->session_is('/s3' => [1, 3])
-    ->session_like('/s1' => qr/data/, 's3 contains "data"')
-    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
+    ->session_like('/s1' => qr/data/, 's1 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's1 does not contain "foo"');
 
   done_testing();
 

--- a/t/Test-Mojo-Session.t
+++ b/t/Test-Mojo-Session.t
@@ -17,7 +17,7 @@ $t->get_ok('/set')
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
     ->session_is('/s3' => [1, 3], 's3 contains right array')
-    ->session_like('/s1' => qr/data/, 's3 contains "data"')
-    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
+    ->session_like('/s1' => qr/data/, 's1 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's1 does not contain "foo"');
 
 done_testing();

--- a/t/Test-Mojo-Session.t
+++ b/t/Test-Mojo-Session.t
@@ -16,6 +16,8 @@ $t->get_ok('/set')
     ->session_has('/s1')
     ->session_is('/s1' => 'session data')
     ->session_hasnt('/s2')
-    ->session_is('/s3' => [1, 3], 's3 containse right array');
+    ->session_is('/s3' => [1, 3], 's3 contains right array')
+    ->session_like('/s1' => qr/data/, 's3 contains "data"')
+    ->session_unlike('/s1' => qr/foo/, 's3 does not contain "foo"');
 
 done_testing();


### PR DESCRIPTION
These commits add the session_like() and session_unlike() methods.  This is much smoother than doing this in a test with a _private method:

`like $t->_extract_session->{session}, qr/foo/, 'session matches';`

(Also I fixed a couple typos in the documentation.)